### PR TITLE
Use special syntax for control key codes rather than hardcoded ordinals

### DIFF
--- a/selecta
+++ b/selecta
@@ -19,12 +19,11 @@ end
 
 require "io/console"
 
-# I don't know how to get these key codes other than by hard-coding the
-# ordinals
-KEY_CTRL_C = 3.chr
-KEY_CTRL_N = 14.chr
-KEY_CTRL_P = 16.chr
-KEY_CTRL_W = 23.chr
+KEY_CTRL_C = ?\C-c
+KEY_CTRL_N = ?\C-n
+KEY_CTRL_P = ?\C-p
+KEY_CTRL_W = ?\C-w
+# I don't know how to get this key code other than by hard-coding the ordinal
 KEY_DELETE = 127.chr
 
 class Selecta


### PR DESCRIPTION
Ruby has an obscure syntax for representing control+letter keycodes as a literal.

You might want to consider using this for ^C, ^N, ^P and ^W. I don't know how to represent delete, so I've left it as is.
