### PR TITLE
Word boundary match

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Ranking algorithm:
   of "crate" that matches).
 - Shorter overall strings match higher ("foo.rb" ranks higher than
   "foo_spec.rb").
+- Uppercase characters in the query must match a word boundary.
+  Word boundaries are pascal and camel cased words
+  and the characters '/', '\', '_', '.' and whitespace.
+  ("FooB" will match "foo/bar" and "fooBar" but not "foobar")
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Ranking algorithm:
   "foo_spec.rb").
 - Uppercase characters in the query must match a word boundary.
   Word boundaries are pascal and camel cased words
-  and the characters '/', '\', '_', '.' and whitespace.
+  and the characters '/', '\', '_', '-', '.' and whitespace.
   ("FooB" will match "foo/bar" and "fooBar" but not "foobar")
 
 ## Installation

--- a/selecta
+++ b/selecta
@@ -224,11 +224,31 @@ class Score
       return 1.0 if query.length == 0
       return 0.0 if choice.length == 0
 
-      choice = choice.downcase
-      query = query.downcase
-
-      match_length = compute_match_length(choice, query.each_char.to_a)
+      match_length = compute_match_length(choice.downcase, query.downcase.each_char.to_a)
       return 0.0 unless match_length
+
+      if query =~ /[A-Z]/
+        choice_tokens = choice.
+          gsub(/([A-Z])/, '_\1'). # camel/pascal case to splittable token
+          downcase.
+          split(%r{[/\\_ ]}). # tokenize
+          reject(&:empty?)
+
+        query_tokens = query.
+          gsub(/([A-Z])/, '_\1').
+          downcase.
+          split(%r{[/\\_ ]}).
+          reject(&:empty?)
+
+        query_tokens.each do |query_token|
+          begin
+            return 0.0 if choice_tokens.empty?
+
+            choice_token = choice_tokens.shift
+          end while !(choice_token.start_with?(query_token[0]) &&
+                      compute_match_length(choice.downcase, query_token.each_char.to_a))
+        end
+      end
 
       # Penalize longer matches.
       score = query.length.to_f / match_length.to_f

--- a/selecta
+++ b/selecta
@@ -282,31 +282,29 @@ end
 
 class TokenMatch
   def initialize(choice, query)
-    @choice = choice.downcase
-    @choice_chars = create_tokenizable_string(choice).each_char.to_a
+    @choice = create_tokenizable_string(choice)
     @query_tokens = tokenize(query)
-    @latest_char = ''
   end
 
   def matches?
     @query_tokens.each do |query_token|
-      return false if @choice_chars.empty?
+      return false if @choice.empty?
 
       # Find the next token separator followed
       # by the first query token char
-      next_char('_', query_token[0])
+      next_substring("_#{query_token[0]}")
 
       # Find all the remaining chars in the
       # query token
       query_token.chars.drop(1).each do |char|
-        next_char(char)
+        next_substring(char)
       end
     end
 
     # If we haven't exhausted the `choice` and
     # all query tokens have been processed
     # we're fine
-    !!@latest_char
+    !@choice.empty?
   end
 
   def tokenize(string)
@@ -315,23 +313,20 @@ class TokenMatch
       reject(&:empty?)
   end
 
-  # Advances to the next `first_char` in the
-  # choice string. Advances to the `second_char` if given,
-  # after the `first_char` has been found.
-  def next_char(first_char, second_char = nil)
-    # We need to swap the first with
-    # the second char (because recursion)
-    if second_char
-      first_char, second_char = second_char, first_char
+  # Advances to the next `substring` in the
+  # choice string. If the `substring` is more
+  # than 1 char we advance to the end of the
+  # match.
+  def next_substring(substring)
+    return if @choice.empty?
+
+    index = @choice.index(substring)
+    if index
+      # advance if substring is more than 1 char
+      @choice = @choice[(index + substring.length - 1)..-1]
+    else
+      @choice = ''
     end
-
-    while @latest_char && @latest_char != first_char
-      next_char(second_char) if second_char
-
-      @latest_char = @choice_chars.shift
-    end
-
-    @latest_char
   end
 
   def create_tokenizable_string(string)

--- a/selecta
+++ b/selecta
@@ -332,7 +332,7 @@ class TokenMatch
   def create_tokenizable_string(string)
     tokenizable_string = string.
       gsub(/([A-Z])/, '_\1').
-      gsub(%r{[/\\_\. ]}, '_').
+      gsub(%r{[/\\_\-\. ]}, '_').
       downcase
     "_#{tokenizable_string}"
   end

--- a/selecta
+++ b/selecta
@@ -285,35 +285,53 @@ class TokenMatch
     @choice = choice.downcase
     @choice_chars = create_tokenizable_string(choice).each_char.to_a
     @query_tokens = tokenize(query)
+    @latest_char = ''
   end
 
   def matches?
-    char = ''
     @query_tokens.each do |query_token|
       return false if @choice_chars.empty?
 
-      while char && char != query_token[0]
-        while char && char != '_'
-          char = @choice_chars.shift
-        end
+      # Find the next token separator followed
+      # by the first query token char
+      next_char('_', query_token[0])
 
-        char = @choice_chars.shift
-      end
-
-      query_token.chars.drop(1).each do |query_token_char|
-        while char && char != query_token_char
-          char = @choice_chars.shift
-        end
+      # Find all the remaining chars in the
+      # query token
+      query_token.chars.drop(1).each do |char|
+        next_char(char)
       end
     end
 
-    !!char
+    # If we haven't exhausted the `choice` and
+    # all query tokens have been processed
+    # we're fine
+    !!@latest_char
   end
 
   def tokenize(string)
     create_tokenizable_string(string).
       split('_').
       reject(&:empty?)
+  end
+
+  # Advances to the next `first_char` in the
+  # choice string. Advances to the `second_char` if given,
+  # after the `first_char` has been found.
+  def next_char(first_char, second_char = nil)
+    # We need to swap the first with
+    # the second char (because recursion)
+    if second_char
+      first_char, second_char = second_char, first_char
+    end
+
+    while @latest_char && @latest_char != first_char
+      next_char(second_char) if second_char
+
+      @latest_char = @choice_chars.shift
+    end
+
+    @latest_char
   end
 
   def create_tokenizable_string(string)

--- a/selecta
+++ b/selecta
@@ -228,26 +228,7 @@ class Score
       return 0.0 unless match_length
 
       if query =~ /[A-Z]/
-        choice_tokens = choice.
-          gsub(/([A-Z])/, '_\1'). # camel/pascal case to splittable token
-          downcase.
-          split(%r{[/\\_ ]}). # tokenize
-          reject(&:empty?)
-
-        query_tokens = query.
-          gsub(/([A-Z])/, '_\1').
-          downcase.
-          split(%r{[/\\_ ]}).
-          reject(&:empty?)
-
-        query_tokens.each do |query_token|
-          begin
-            return 0.0 if choice_tokens.empty?
-
-            choice_token = choice_tokens.shift
-          end while !(choice_token.start_with?(query_token[0]) &&
-                      compute_match_length(choice.downcase, query_token.each_char.to_a))
-        end
+        return 0.0 unless TokenMatch.new(choice, query).matches?
       end
 
       # Penalize longer matches.
@@ -296,6 +277,35 @@ class Score
       end
       last_index
     end
+  end
+end
+
+class TokenMatch
+  def initialize(choice, query)
+    @choice = choice.downcase
+    @choice_tokens = tokenize(choice)
+    @query_tokens = tokenize(query)
+  end
+
+  def matches?
+    @query_tokens.each do |query_token|
+      begin
+        return false if @choice_tokens.empty?
+
+        choice_token = @choice_tokens.shift
+      end while !(choice_token.start_with?(query_token[0]) &&
+                  Score.compute_match_length(@choice, query_token.each_char.to_a))
+    end
+
+    true
+  end
+
+  def tokenize(string)
+    string.
+      gsub(/([A-Z])/, '_\1'). # camel/pascal case to splittable token
+      downcase.
+      split(%r{[/\\_ ]}). # tokenize
+      reject(&:empty?)
   end
 end
 

--- a/selecta
+++ b/selecta
@@ -283,29 +283,45 @@ end
 class TokenMatch
   def initialize(choice, query)
     @choice = choice.downcase
-    @choice_tokens = tokenize(choice)
+    @choice_chars = create_tokenizable_string(choice).each_char.to_a
     @query_tokens = tokenize(query)
   end
 
   def matches?
+    char = ''
     @query_tokens.each do |query_token|
-      begin
-        return false if @choice_tokens.empty?
+      return false if @choice_chars.empty?
 
-        choice_token = @choice_tokens.shift
-      end while !(choice_token.start_with?(query_token[0]) &&
-                  Score.compute_match_length(@choice, query_token.each_char.to_a))
+      while char && char != query_token[0]
+        while char && char != '_'
+          char = @choice_chars.shift
+        end
+
+        char = @choice_chars.shift
+      end
+
+      query_token.chars.drop(1).each do |query_token_char|
+        while char && char != query_token_char
+          char = @choice_chars.shift
+        end
+      end
     end
 
-    true
+    !!char
   end
 
   def tokenize(string)
-    string.
-      gsub(/([A-Z])/, '_\1'). # camel/pascal case to splittable token
-      downcase.
-      split(%r{[/\\_\. ]}). # tokenize
+    create_tokenizable_string(string).
+      split('_').
       reject(&:empty?)
+  end
+
+  def create_tokenizable_string(string)
+    tokenizable_string = string.
+      gsub(/([A-Z])/, '_\1').
+      gsub(%r{[/\\_\. ]}, '_').
+      downcase
+    "_#{tokenizable_string}"
   end
 end
 

--- a/selecta
+++ b/selecta
@@ -304,7 +304,7 @@ class TokenMatch
     string.
       gsub(/([A-Z])/, '_\1'). # camel/pascal case to splittable token
       downcase.
-      split(%r{[/\\_ ]}). # tokenize
+      split(%r{[/\\_\. ]}). # tokenize
       reject(&:empty?)
   end
 end

--- a/selecta
+++ b/selecta
@@ -282,8 +282,8 @@ end
 
 class TokenMatch
   def initialize(choice, query)
-    @choice = create_tokenizable_string(choice)
-    @query_tokens = tokenize(query)
+    @choice = tokenizable_string(choice)
+    @query_tokens = tokens(query)
   end
 
   def matches?
@@ -307,10 +307,19 @@ class TokenMatch
     !@choice.empty?
   end
 
-  def tokenize(string)
-    create_tokenizable_string(string).
+  def tokens(string)
+    tokenizable_string(string).
       split('_').
       reject(&:empty?)
+  end
+
+  def tokenizable_string(string)
+    tokenizable_string = string.
+      gsub(/([A-Z])/, '_\1').
+      gsub(%r{[/\\_\-\. ]}, '_').
+      downcase
+
+    "_#{tokenizable_string}"
   end
 
   # Advances to the next `substring` in the
@@ -321,20 +330,8 @@ class TokenMatch
     return if @choice.empty?
 
     index = @choice.index(substring)
-    if index
-      # advance if substring is more than 1 char
-      @choice = @choice[(index + substring.length - 1)..-1]
-    else
-      @choice = ''
-    end
-  end
-
-  def create_tokenizable_string(string)
-    tokenizable_string = string.
-      gsub(/([A-Z])/, '_\1').
-      gsub(%r{[/\\_\-\. ]}, '_').
-      downcase
-    "_#{tokenizable_string}"
+    # advance if substring is more than 1 char
+    @choice = index ? @choice[(index + substring.length - 1)..-1] : ''
   end
 end
 

--- a/spec/score_spec.rb
+++ b/spec/score_spec.rb
@@ -48,7 +48,6 @@ describe "score" do
     end
 
     it "is case insensitive" do
-      score("a", "A").should == 1.0
       score("A", "a").should == 1.0
     end
 
@@ -85,5 +84,39 @@ describe "score" do
 
   xit "prefers acronyms to normal matches" do
     score("Foo Bar", "fb").should be > score("foo bar", "fb")
+  end
+
+  describe "uppercase search -> boundary matches" do
+    it "matches word boundaries" do
+      score("foo bar", "FB").should > 0.0
+      score("foobar", "FB").should == 0.0
+    end
+
+    it "matches snake cased words" do
+      score("foo_bar", "FB").should > 0.0
+      score("foobar", "FB").should == 0.0
+    end
+
+    it "matches pascal cased words" do
+      score("FooBar", "FB").should > 0.0
+      score("Foobar", "FB").should == 0.0
+    end
+
+    it "matches camel cased words" do
+      score("fooBar", "FB").should > 0.0
+      score("foobar", "FB").should == 0.0
+    end
+
+    it "matches path parts" do
+      score("foo/bar", "FB").should > 0.0
+      score("foo/rab", "FB").should == 0.0
+    end
+
+    it "combined upper and lower cased query" do
+      score("foo/bar", "FooB").should > 0.0
+      score("foo/rab", "FooB").should == 0.0
+      score("foo/rab", "Foob").should > 0.0
+      score("foo_bar", "FBr").should > 0.0
+    end
   end
 end

--- a/spec/score_spec.rb
+++ b/spec/score_spec.rb
@@ -97,6 +97,11 @@ describe "score" do
       score("foobar", "FB").should == 0.0
     end
 
+    it "matches dot separated words" do
+      score("foo.bar", "FB").should > 0.0
+      score("foobar", "FB").should == 0.0
+    end
+
     it "matches pascal cased words" do
       score("FooBar", "FB").should > 0.0
       score("Foobar", "FB").should == 0.0

--- a/spec/score_spec.rb
+++ b/spec/score_spec.rb
@@ -123,5 +123,11 @@ describe "score" do
       score("foo/rab", "Foob").should > 0.0
       score("foo_bar", "FBr").should > 0.0
     end
+
+    it "allows lowercase matches only between tokens" do
+      score("foo/rab", "Foob").should > 0.0
+      score("foo_bab", "FoaB").should == 0.0
+      score("foo_abab_B", "FoaB").should > 0.0
+    end
   end
 end

--- a/spec/score_spec.rb
+++ b/spec/score_spec.rb
@@ -102,6 +102,11 @@ describe "score" do
       score("foobar", "FB").should == 0.0
     end
 
+    it "matches dash separated words" do
+      score("foo-bar", "FB").should > 0.0
+      score("foobar", "FB").should == 0.0
+    end
+
     it "matches pascal cased words" do
       score("FooBar", "FB").should > 0.0
       score("Foobar", "FB").should == 0.0

--- a/spec/score_spec.rb
+++ b/spec/score_spec.rb
@@ -121,6 +121,9 @@ describe "score" do
     it "matches path parts" do
       score("foo/bar", "FB").should > 0.0
       score("foo/rab", "FB").should == 0.0
+
+      score("foo\\bar", "FB").should > 0.0
+      score("foo\\rab", "FB").should == 0.0
     end
 
     it "combined upper and lower cased query" do

--- a/spec/score_spec.rb
+++ b/spec/score_spec.rb
@@ -105,6 +105,7 @@ describe "score" do
     it "matches pascal cased words" do
       score("FooBar", "FB").should > 0.0
       score("Foobar", "FB").should == 0.0
+      score("FooSbar", "FB").should == 0.0
     end
 
     it "matches camel cased words" do


### PR DESCRIPTION
New feature: 
Searching with uppercase letters searches for word boundaries.
This allows for faster searching, e.g. for paths.

Examples:

 * "FoB" will match "foo/bar"
 * "FoB" will match "fooBar"
 * "FoB" will **not** match "foobar"

See the specs for more examples.

Word boundaries are:

 * pascal and camel cased words
 * the characters '/', '\', '_', '-', '.' and whitespace.