### PR TITLE
Finish the search immediately if there are no choices

### DIFF
--- a/selecta
+++ b/selecta
@@ -175,7 +175,7 @@ class Search
   end
 
   def done?
-    @done
+    config.choices.empty? || @done
   end
 
   def selected_choice

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -77,6 +77,12 @@ describe Search do
     search.done.done?.should == true
   end
 
+  it "is done if there are no choices" do
+    config = Configuration.from_inputs([], Configuration.default_options)
+    search = Search.blank(config)
+    search.done?.should == true
+  end
+
   it "handles not matching" do
     lambda { search.append_search_string("a").selected_choice }
       .should raise_error(SystemExit)


### PR DESCRIPTION
Say you're piping in output from `ls`—there's no guarantee that you'll get
anything on `stdin`. We should be able to consider the search done if there are
no choices.
