### PR TITLE
Read input from ARGF

### DIFF
--- a/selecta
+++ b/selecta
@@ -38,7 +38,7 @@ class Selecta
     options = Configuration.parse_options(ARGV)
 
     search = Screen.with_screen do |screen, tty|
-      config = Configuration.from_inputs($stdin.readlines, options, screen.height)
+      config = Configuration.from_inputs(ARGF.readlines, options, screen.height)
       run_in_screen(config, screen, tty)
     end
 


### PR DESCRIPTION
Swap `$stdin` for `ARGV` in order to directly handle bash process substitution.

I wanted to collect the output of several commands and pipe it into `selecta`. I arrived at the following which worked great:

``` bash
$ cat <(echo foo) <(echo bar) <(echo baz) | selecta
>
foo
bar
baz
```

Taking it another step, I tried to use `selecta` directly to no avail. By using `ARGF`, the result is the same as the above example:

``` bash
$ selecta <(echo foo) <(echo bar) <(echo baz)
>
foo
bar
baz
```

I've only tested briefly on my system (OS X 10.9.2; ruby 2.1.1p76). I know this project handles many edge cases, platforms, and the like, so it's possible `ARGF` may not be appropriate.
