### PR TITLE
Add open vim buffer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ endfunction
 nnoremap <leader>f :call SelectaCommand("find * -type f", "", ":e")<cr>
 ```
 
-You can also use selecta to open buffers, just add the following to your .vimrc:
+You can also use selecta to open buffers. Just add the following to your .vimrc:
 
 ```vimscript
 function! SelectaBuffer()

--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ endfunction
 nnoremap <leader>f :call SelectaCommand("find * -type f", "", ":e")<cr>
 ```
 
+You can also use selecta to open buffers, just add the following to your .vimrc:
+
+```vimscript
+function! SelectaBuffer()
+  let buffers = []
+  for i in range(1, bufnr("$"))
+    call add(buffers, bufname(i))
+  endfor
+  let options = join(buffers, "\n")
+  call SelectaCommand('echo "' . options . '"', "", ":e")
+endfunction
+
+" Fuzzy select a buffer. Open the selected buffer with :e.
+nnoremap <leader>b :call SelectaBuffer()<cr>
+```
+
 ## Usage Examples
 
 #### Check out a git branch

--- a/README.md
+++ b/README.md
@@ -115,12 +115,8 @@ You can also use selecta to open buffers, just add the following to your .vimrc:
 
 ```vimscript
 function! SelectaBuffer()
-  let buffers = []
-  for i in range(1, bufnr("$"))
-    call add(buffers, bufname(i))
-  endfor
-  let options = join(buffers, "\n")
-  call SelectaCommand('echo "' . options . '"', "", ":e")
+  let buffers = map(range(1, bufnr("$")), 'bufname(bufnr(v:val))')
+  call SelectaCommand('echo "' . join(buffers, "\n") . '"', "", ":e")
 endfunction
 
 " Fuzzy select a buffer. Open the selected buffer with :e.

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ You can also use selecta to open buffers. Just add the following to your .vimrc:
 ```vimscript
 function! SelectaBuffer()
   let buffers = map(range(1, bufnr("$")), 'bufname(bufnr(v:val))')
-  call SelectaCommand('echo "' . join(buffers, "\n") . '"', "", ":e")
+  call SelectaCommand('echo "' . join(buffers, "\n") . '"', "", ":b")
 endfunction
 
-" Fuzzy select a buffer. Open the selected buffer with :e.
+" Fuzzy select a buffer. Open the selected buffer with :b.
 nnoremap <leader>b :call SelectaBuffer()<cr>
 ```
 


### PR DESCRIPTION
There's probably a better way to do this, but I at least wanted to start the conversation. Here's what I have so far. The code is pretty self-explanatory and leverages the existing SelectaCommand. It works well so far.

Until you have a vim plugin I can use, I've started collecting these in my own: https://github.com/michaelavila/selecta.vim

I don't know if anyone else will find this valuable, but I use buffers and selecta heavily. I'm happy to have selecta to make the experience better.