### PR TITLE
Add bash path-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ proj() {
 
 #### Insert fuzzy-found paths directly into the shell command line
 
-Whenever you press ^S, your shell will run `find * -type f | selecta` and
+Whenever you press ^S, your shell will run `find . -type f | selecta` and
 append the resulting selected path to the current command line.
 
 Caveats:
@@ -188,7 +188,7 @@ function insert-selecta-path-in-command-line() {
     # Print a newline or we'll clobber the old prompt.
     echo
     # Find the path; abort if the user doesn't select anything.
-    selected_path=$(find * -type f | selecta) || return
+    selected_path=$(find . -type f | selecta) || return
     # Append the selection to the current command buffer.
     eval 'LBUFFER="$LBUFFER$selected_path"'
     # Redraw the prompt since Selecta has drawn several new lines of text.
@@ -206,7 +206,7 @@ Put it in your `~/.bashrc`.
 
 ```shell
 function insert_selecta_path_in_command_line() {
-    READLINE_LINE+=$(find * -type f | selecta)
+    READLINE_LINE+=$(find . -type f | selecta)
 }
 
 bind -x '"\C-s":"insert_selecta_path_in_command_line"'

--- a/README.md
+++ b/README.md
@@ -161,16 +161,21 @@ proj() {
 
 #### Insert fuzzy-found paths directly into the shell command line
 
-This only works with zsh (patches to make it work with Bash would be
-appreciated). Put it in your ~/.zshrc. Then, whenever you press ^S, zsh will
-run `find * -type f | selecta` and append the resulting selected path to the
-current command line.
+Whenever you press ^S, your shell will run `find * -type f | selecta` and
+append the resulting selected path to the current command line.
 
-Caveats: 1) You're running `find` in the current working directory. If you do
-it in a large directory, like ~, then it's going to take a while. 2) This also
-disables flow control to free up the ^S keystroke. If you normally use ^S and
-^Q, you may want to map to a different key and remove the `unsetopt
-flowcontrol`.
+Caveats:
+
+1. You're running `find` in the current working directory. If you do it in a
+   large directory, like ~, then it's going to take a while.
+
+2. This also disables flow control to free up the ^S keystroke. If you normally
+   use ^S and ^Q, you may want to map to a different key (and in zsh's case
+   remove the `unsetopt flowcontrol`).
+
+##### zsh
+
+Put it in your `~/.zshrc`.
 
 ```shell
 # By default, ^S freezes terminal output and ^Q resumes it. Disable that so
@@ -194,6 +199,19 @@ zle -N insert-selecta-path-in-command-line
 # Bind the key to the newly created widget
 bindkey "^S" "insert-selecta-path-in-command-line"
 ```
+
+##### bash
+
+Put it in your `~/.bashrc`.
+
+```shell
+function insert_selecta_path_in_command_line() {
+    READLINE_LINE+=$(find * -type f | selecta)
+}
+
+bind -x '"\C-s":"insert_selecta_path_in_command_line"'
+```
+
 
 ## FAQ
 


### PR DESCRIPTION
I am unsure whether flowcontrol has to be disabled for bash. It doesn't
seem so to me, but testing is appreciated.

A new name has been chosen because the old one wasn't recognized as a
valid identifier by my shell.