### PR TITLE
Correct IndexError when scrolling through matches

### DIFF
--- a/selecta
+++ b/selecta
@@ -237,7 +237,7 @@ class Search
   end
 
   def max_visible_choices
-    [@config.visible_choices, choices.count].min
+    [@config.visible_choices, choices.count, matches.count].min
   end
 
   def append_search_string(string)


### PR DESCRIPTION
Since `choices` never changes when filtering matches, it would let `up` and `down` scoll past the current number of matches, resulting in an `IndexError` when rendering.

`matches`, however, gives accurate bounds for scrolling.

I'm unsure if `choices.count` still needs to be in `#max_visible_choices`, since with a blank search string it and `matches.count` are equal. I'll remove it if you want me to.

The bug in question:

![IndexError Bug](http://i.imgur.com/SO7ZGfC.gif)