### PR TITLE
Append a space to the selected path after ^S

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ flowcontrol`.
 # that those keys can be used for other things.
 unsetopt flowcontrol
 # Run Selecta in the current working directory, appending the selected path, if
-# any, to the current command.
+# any, to the current command, followed by a space.
 function insert-selecta-path-in-command-line() {
     local selected_path
     # Print a newline or we'll clobber the old prompt.
@@ -201,7 +201,7 @@ function insert-selecta-path-in-command-line() {
     # Find the path; abort if the user doesn't select anything.
     selected_path=$(find * -type f | selecta) || return
     # Append the selection to the current command buffer.
-    eval 'LBUFFER="$LBUFFER$selected_path"'
+    eval 'LBUFFER="$LBUFFER$selected_path "'
     # Redraw the prompt since Selecta has drawn several new lines of text.
     zle reset-prompt
 }


### PR DESCRIPTION
This is a slight ergonomic tweak to the sample code of `insert-selecta-path-in-command-line`. Appending a space to the selected path makes it easier to select multiple paths, which I usually want to do for my most frequent use case of ^S (invoking `git add`).