### PR TITLE
Preserve case of inputs for rendering

### DIFF
--- a/selecta
+++ b/selecta
@@ -366,11 +366,11 @@ class Match < Struct.new(:original_choice, :choice, :score, :matching_range)
 
   def to_text
     if matching_range.none?
-      Text[choice]
+      Text[original_choice]
     else
-      before = choice[0...matching_range.begin]
-      matching = choice[matching_range.begin..matching_range.end]
-      after = choice[(matching_range.end + 1)..-1]
+      before = original_choice[0...matching_range.begin]
+      matching = original_choice[matching_range.begin..matching_range.end]
+      after = original_choice[(matching_range.end + 1)..-1]
       Text[before, :red, matching, :default, after]
     end
   end

--- a/spec/renderer_spec.rb
+++ b/spec/renderer_spec.rb
@@ -26,14 +26,14 @@ describe Renderer do
   end
 
   it "respects the screen height" do
-    config = Configuration.from_inputs(["one", "two", "three"],
+    config = Configuration.from_inputs(["One", "two", "three"],
                                        Configuration.default_options,
                                        2)
     search = Search.blank(config)
     renderer = Renderer.new(search)
     expect(renderer.render.choices).to eq [
       "3 > ",
-      Text[:inverse, "one", :reset],
+      Text[:inverse, "One", :reset],
     ]
   end
 


### PR DESCRIPTION
Uses `Match#original_choice` for rendering instead of `Match#choice`

Resolves the bug mentioned in #80 