### PR TITLE
When selecta is started with only one line of input, automatically select that line.

### DIFF
--- a/selecta
+++ b/selecta
@@ -141,8 +141,8 @@ class Selecta
   class Abort < RuntimeError; end
 end
 
-class Configuration < Struct.new(:height, :initial_search, :choices)
-  def initialize(height, initialize, choices)
+class Configuration < Struct.new(:height, :initial_search, :auto, :choices)
+  def initialize(height, initialize, auto, choices)
     # Constructor is defined to force argument presence; otherwise Struct
     # defaults missing arguments to nil
     super
@@ -161,7 +161,7 @@ class Configuration < Struct.new(:height, :initial_search, :choices)
     end
 
     choices = massage_choices(choices)
-    Configuration.new(height, options.fetch(:search), choices)
+    Configuration.new(height, options.fetch(:search), options.fetch(:auto), choices)
   end
 
   def self.default_options
@@ -169,7 +169,7 @@ class Configuration < Struct.new(:height, :initial_search, :choices)
   end
 
   def self.parse_options(argv)
-    options = {:search => "", :height => 21}
+    options = {:search => "", :height => 21, :auto => false}
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
@@ -197,6 +197,10 @@ class Configuration < Struct.new(:height, :initial_search, :choices)
 
       opts.on("-s", "--search SEARCH", "Specify an initial search string") do |search|
         options[:search] = search
+      end
+
+      opts.on("-a", "--auto", "If only one line of text is provided, automatically select it") do |search|
+        options[:auto] = true
       end
     end
 
@@ -259,7 +263,9 @@ class Search
                  :all_matches => trivial_matches,
                  :best_matches => trivial_matches)
 
-    if config.initial_search.empty?
+    if config.auto and config.choices.length == 1
+      search.merge(:done => true)
+    elsif config.initial_search.empty?
       search
     else
       search.append_search_string(config.initial_search)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -56,5 +56,18 @@ describe Configuration do
         expect(config.initial_search).to eq("")
       end
     end
+
+    describe "auto matching" do
+      it "can be specified" do
+        config = Configuration.from_inputs(
+          [], Configuration.parse_options(["-a"]))
+        expect(config.auto).to eq true
+      end
+
+      it "defaults to false" do
+        config = Configuration.from_inputs([], Configuration.default_options)
+        expect(config.auto).to eq false
+      end
+    end
   end
 end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -26,7 +26,7 @@ describe Search do
       it "loops around when reaching the visible choice limit" do
         # The UI height here is 3, but the prompt line subtracts 1, so only two
         # choices are shown.
-        config = Configuration.new(3, "", ["one", "two", "three"])
+        config = Configuration.new(3, "", false, ["one", "two", "three"])
         search = Search.from_config(config)
         expect(search.down.down.down.selection).to eq "two"
       end
@@ -55,7 +55,7 @@ describe Search do
     end
 
     describe "initial search string" do
-      let(:config) { Configuration.new(2, "thr", ["one", "two", "three"]) }
+      let(:config) { Configuration.new(2, "thr", false, ["one", "two", "three"]) }
       let(:search) { Search.from_config(config) }
 
       it "is remembered" do
@@ -132,5 +132,33 @@ describe Search do
   it "knows when it's done" do
     expect(search.done?).to eq false
     expect(search.done.done?).to eq true
+  end
+
+  describe "auto(matic) selection when there is just single choice" do
+    let(:oneline)      { ["first"] }
+    describe "when the automatic option is on" do
+      let(:autoconfig) { Configuration.from_inputs(oneline,
+                                                   Configuration.parse_options(['--auto'])) }
+      let(:autosearch) { Search.from_config(autoconfig) }
+
+      it "finds that the search is already done" do
+        expect(autosearch.done?).to be true
+      end
+
+      it "returns the first line as a match" do
+        expect(autosearch.selection).to eq oneline.first
+      end
+    end
+
+    describe "when the automatic option is off" do
+      let(:twolines)   { ["first", "second"] }
+      let(:autoconfig) { Configuration.from_inputs(twolines,
+                                                   Configuration.parse_options(['--auto'])) }
+      let(:autosearch) { Search.from_config(autoconfig) }
+
+      it "finds that the search is still going" do
+        expect(autosearch.done?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Useful for running selecta a from shell script where there is a non-destructive selection involved, i.e. starting VLC.
