### PR TITLE
Fix Ruby 4.0 compatibility

### DIFF
--- a/selecta
+++ b/selecta
@@ -790,7 +790,7 @@ class TTY < Struct.new(:console_file)
 
   def get_available_input
     input = console_file.getc
-    while console_file.ready?
+    while console_file.wait_readable(0)
       input += console_file.getc
     end
     input


### PR DESCRIPTION
The `ready?` method has been removed in Ruby 4.0. This change replaces it with a call to `.wait_readable(0)`.

Fixes #111.